### PR TITLE
Fix likely typo'd symbol name.

### DIFF
--- a/CommonLibF4/include/RE/Bethesda/BGSCreatedObjectManager.h
+++ b/CommonLibF4/include/RE/Bethesda/BGSCreatedObjectManager.h
@@ -58,7 +58,7 @@ namespace RE
 
 		void DecrementRef(AlchemyItem* a_alchItem)
 		{
-			using func_t = decltype(&BGSCreatedObjectManager::IncrementRef);
+			using func_t = decltype(&BGSCreatedObjectManager::DecrementRef);
 			REL::Relocation<func_t> func{ REL::ID(230928) };
 			return func(this, a_alchItem);
 		}


### PR DESCRIPTION
Mostly harmless since the two functions have identical type declarations,
but may be desirable to fix nevertheless.