### PR TITLE
initialize BaseExtraList flags to 0

### DIFF
--- a/CommonLibF4/include/RE/Bethesda/BSExtraData.h
+++ b/CommonLibF4/include/RE/Bethesda/BSExtraData.h
@@ -619,7 +619,11 @@ namespace RE
 			return !((stl::to_underlying(a_type) - 11) & ~0x22u) && a_type != EXTRA_DATA_TYPE::kLeveledCreature;
 		}
 
-		void CreateFlags() { _flags = calloc<std::uint8_t>(N); }
+		void CreateFlags()
+		{
+			_flags = calloc<std::uint8_t>(N);
+			std::memset(_flags, 0, N);
+		}
 
 		[[nodiscard]] std::span<std::uint8_t> GetFlags() const noexcept
 		{


### PR DESCRIPTION
calloc appears to return random data instead of initializing the flag list with zeros. 

This results in inconsistent behavior when modifying the extra data list. Given that methods such as HasType or MarkType check these flags to verify if an extra data type is part of the list.