### PR TITLE
Add `overlay-ports` to vcpkg.json, fix CMakePrests.sjon

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,11 +22,7 @@
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": {
           "type": "STRING",
-          "value": "$env{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
-        },
-        "VCPKG_OVERLAY_PORTS": {
-          "type": "STRING",
-          "value": "${sourceDir}/cmake/ports/"
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
         }
       },
       "hidden": true,

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,5 +13,8 @@
     "spdlog",
     "srell",
     "xbyak"
-  ]
+  ],
+  "vcpkg-configuration": {
+    "overlay-ports": [ "./cmake/ports/" ]
+  }
 }


### PR DESCRIPTION
* `overlay-ports`: 
vcpkg added this in the 2022.11.14 release:
https://devblogs.microsoft.com/cppblog/vcpkg-2022-11-14-and-2022-10-19-releases-localization-for-14-languages-overlay-ports-triplets-in-manifests-acquire-project-command-and-more/

* Remove `VCPKG_OVERLAY_PORTS`, no longer needed
* fix toolchain file: `VCPKG_INSTALLATION_ROOT` is not the default envvar set by vcpkg or its various installers, it's `VCPKG_ROOT`