### PR TITLE
CI: add `static_checks.yml`

### DIFF
--- a/.github/scripts/check_clang_format.sh
+++ b/.github/scripts/check_clang_format.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+CLANG_FORMAT=clang-format-12
+
+CURRENT_BRANCH="$(git branch --show-current)"
+
+# If this was triggered by a pull request...
+if [ -n "$GITHUB_BASE_REF" ]; then
+    # Test from the the last commit of base branch to head of pull request
+    RANGE="$(git rev-parse $GITHUB_BASE_REF) HEAD"
+# Otherwise, if we're not on master, check from the merge base of master
+elif [ "$CURRENT_BRANCH" != "master" ]; then
+	RANGE="$(git merge-base HEAD master) HEAD"
+# Otherwise, check last commit
+else
+	RANGE=HEAD
+fi
+
+echo "Checking $RANGE"
+FILES=$(git diff-tree --no-commit-id --name-only -r $RANGE | grep -E "\.(c|h|cpp|hpp|cc|hh|cxx|m|mm|inc)$")
+echo "Checking files:\n$FILES"
+
+# create a random filename to store our generated patch
+prefix="static-check-clang-format"
+suffix="$(date +%s)"
+patch="/tmp/$prefix-$suffix.patch"
+
+for file in $FILES; do
+    "$CLANG_FORMAT" -style=file "$file" | \
+        diff -u "$file" - | \
+        sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patch"
+done
+
+# if no patch has been generated all is ok, clean up the file stub and exit
+if [ ! -s "$patch" ] ; then
+    printf "Files in this commit comply with the clang-format rules.\n"
+    rm -f "$patch"
+    exit 0
+fi
+
+# a patch has been created, notify the user and exit
+printf "\n*** The following differences were found between the code to commit "
+printf "and the clang-format rules:\n\n"
+cat "$patch"
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+exit 1

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,6 +1,6 @@
 name: Scripted maintenance
 
-on: [ push, pull_request_target ]
+on: [ push ]
 
 jobs:
   maintenance:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,0 +1,35 @@
+﻿name: Static checks
+
+on: [ pull_request ]
+
+jobs:
+  check-clang-formatting:
+    name: "Check Formatting"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+      # we get the necessary commits below
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    # If we're on another branch, make sure we have master
+    - name: fetch rest of history
+      run: |
+        git fetch --prune
+        echo $(git branch --all)
+        CURR_BRANCH=$(git branch --show-current)
+        if [ "$CURR_BRANCH" = "" ]; then
+          CURR_BRANCH=$(git rev-parse HEAD)
+        fi
+        if [ "$CURR_BRANCH" != "master" ]; then
+          git checkout --track origin/master
+          git checkout $CURR_BRANCH
+        fi
+        echo $(git branch --all)
+    - name: check clang_format
+      run: bash ./.github/scripts/check_clang_format.sh


### PR DESCRIPTION
This fixes issues with `maintenance` failing. This should only be run on `push` since it has access to the github secrets and modifies the git history.

Instead, on PRs, run `clang_format` on only the changed files in the PR to determine if the PR follows the formatting rules, and if not, output the diff and fail.